### PR TITLE
feat: personalize site for Frank Goortani

### DIFF
--- a/components/nav-links.css
+++ b/components/nav-links.css
@@ -12,6 +12,9 @@
 .nav-links-link1 {
   text-decoration: none;
 }
+.nav-links-link2 {
+  text-decoration: none;
+}
 @media(max-width: 767px) {
   .nav-links-links {
     display: none;

--- a/components/nav-links.html
+++ b/components/nav-links.html
@@ -17,5 +17,13 @@
     >
       <span>Portfolio</span>
     </a>
+    <a
+      href="https://architect.solutions"
+      target="_blank"
+      rel="noreferrer noopener"
+      class="nav-links-link2 navLink"
+    >
+      <span>Blog</span>
+    </a>
   </div>
 </div>

--- a/index.css
+++ b/index.css
@@ -12,6 +12,9 @@
 .nav-links-link1 {
   text-decoration: none;
 }
+.nav-links-link2 {
+  text-decoration: none;
+}
 @media(max-width: 767px) {
   .nav-links-links {
     display: none;

--- a/index.html
+++ b/index.html
@@ -1,39 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>VisionzLab</title>
-    <meta property="og:title" content="VisionzLab" />
+    <title>Frank Goortani | VisionzLab</title>
+    <meta property="og:title" content="Frank Goortani | VisionzLab" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="utf-8" />
     <meta property="twitter:card" content="summary_large_image" />
     <meta name="robots" content="index, follow" />
     <meta
       name="description"
-      content="VisionzLab crafts visual identities for conscious teams building innovative web3 and SaaS products."
+      content="Frank Goortani's VisionzLab delivers AI-driven architecture, automation, and cloud-native solutions."
     />
     <link rel="canonical" href="https://visionzlab.com/" />
     <meta
       property="og:description"
-      content="VisionzLab crafts visual identities for web3 and SaaS innovators."
+      content="Frank Goortani's VisionzLab delivers AI-driven architecture, automation, and cloud-native solutions."
     />
     <meta property="og:url" content="https://visionzlab.com/" />
     <meta property="og:image" content="https://visionzlab.com/public/preview.svg" />
-    <meta name="twitter:title" content="VisionzLab" />
+    <meta name="twitter:title" content="Frank Goortani | VisionzLab" />
     <meta
       name="twitter:description"
-      content="VisionzLab crafts visual identities for web3 and SaaS innovators."
+      content="Frank Goortani's VisionzLab delivers AI-driven architecture, automation, and cloud-native solutions."
     />
     <meta name="twitter:image" content="https://visionzlab.com/public/preview.svg" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Organization",
-        "name": "VisionzLab",
+        "name": "Frank Goortani | VisionzLab",
         "url": "https://visionzlab.com",
         "logo": "https://visionzlab.com/public/preview.svg",
         "contactPoint": {
           "@type": "ContactPoint",
-          "email": "info@visionzlab.com",
+          "email": "frank@goortani.com",
           "telephone": "+1 647.983.5277",
           "contactType": "customer service"
         }
@@ -120,6 +120,14 @@
                     >
                       <span>Portfolio</span>
                     </a>
+                    <a
+                      href="https://architect.solutions"
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      class="nav-links-link2 navLink"
+                    >
+                      <span>Blog</span>
+                    </a>
                   </div>
                   <div class="home-button">
                     <a
@@ -180,8 +188,8 @@
         <div class="home-hero">
           <div class="home-header">
             <h1 class="home-text04">
-              Creating visual identity that fits like a dream for conscious
-              teams with innovative products in web3 and SaaS
+              Frank Goortani builds AI-driven applications, automation, and
+              cloud-native platforms for startups and enterprises.
             </h1>
             <img alt="scroll icon" src="public/mouse.svg" class="home-image02" />
           </div>
@@ -193,16 +201,15 @@
           <div class="home-header1">
             <div class="home-heading">
               <h2 class="home-text05">
-                We are a next-generation technology-driven design and
+                VisionzLab is Frank Goortani's AI-driven architecture and
                 development studio.
               </h2>
               <span class="home-text06">
-                Welcome to our world, where artistry meets technology. We
-                specialize in designing and developing web, mobile, and cloud
-                applications that redefine digital landscapes. Our team of
-                expert designers and developers are committed to delivering
-                exceptional quality in every product, ensuring our clients
-                always stay at the forefront of innovation.
+                Frank Goortani, TOGAF and PMP certified, has over 25 years of
+                experience in generative AI, intelligent automation, and
+                cloud-native architectures. He partners with startups and
+                Fortune 500 companies to align technology with business goals
+                and deliver measurable outcomes.
               </span>
             </div>
             <a
@@ -221,11 +228,9 @@
             <div class="home-purpose">
               <span class="home-caption">What we do</span>
               <span class="home-description">
-                We arrive at business-reflective design decisions by integrating
-                strategic thinking with mature design and transferrable
-                functionality. From helping transform the image of a legacy
-                brand to creating an ultra-modern identity for a space tech
-                startup - we’re always up for a fresh challenge.
+                From generative AI agents and RAG pipelines to enterprise web,
+                mobile, and cloud platforms, we turn ideas into scalable
+                solutions.
               </span>
             </div>
           </div>
@@ -249,10 +254,9 @@
                   class="accordion-content accordion-content-active"
                 >
                   <span class="home-text09">
-                    Get your custom web and cloud applications tailored to your
-                    specific business needs. From concept to deployment, we got
-                    you covered. Our cloud solutions cover public and private
-                    clouds including Salesforce, Azure, GCP and AWS&nbsp;
+                    Design and build scalable web and cloud applications on
+                    Azure, AWS, and GCP. From concept to production, the entire
+                    stack is covered.
                   </span>
                 </div>
               </div>
@@ -268,9 +272,8 @@
                   class="accordion-content accordion-content-active"
                 >
                   <span class="home-text10">
-                    Your customers are on the go and so should your business. We
-                    develop hybrid, native iOS, and Android mobile applications
-                    that are both user-friendly and visually stunning.
+                    Create native and hybrid iOS and Android experiences using
+                    Swift, Kotlin, and modern cross-platform frameworks.
                   </span>
                 </div>
               </div>
@@ -289,10 +292,9 @@
                   class="accordion-content accordion-content-active"
                 >
                   <span class="home-text13">
-                    We automate your software development and IT operations,
-                    ensuring faster delivery of high-quality software. We also
-                    help you scale your Machine Learning processes and enable
-                    you to manage models at scale with our MLOps services.
+                    Automate delivery pipelines and manage machine learning
+                    workflows with Kubernetes, Terraform, and MLOps best
+                    practices.
                   </span>
                 </div>
               </div>
@@ -311,10 +313,9 @@
                   class="accordion-content accordion-content-active"
                 >
                   <span class="home-text16">
-                    We leverage the latest AI technologies to automate your
-                    business processes, enabling you to focus on growing your
-                    business. From chatbots to machine learning algorithms, we
-                    have the expertise to help you maximize automation.
+                    Build LLM-powered agents, RAG pipelines, and intelligent
+                    automation to accelerate workflows and unlock new
+                    capabilities.
                   </span>
                 </div>
               </div>
@@ -334,13 +335,10 @@
                 >
                   <span class="home-text19">
                     <span>
-                      We help you make sense of your data by designing data
-                      architectures, pipelines, and warehouses that are
-                      optimized for your business needs. Get ready to make
-                      data-driven decisions!
+                      Architect data pipelines, warehouses, and governance
+                      models that turn raw data into reliable insights and
+                      dashboards.
                     </span>
-                    <br />
-                    <br />
                   </span>
                 </div>
               </div>
@@ -430,7 +428,7 @@
           <div class="home-content">
             <div class="home-left">
               <h2 class="home-text23">
-                Book a 15 minutes consultation to check how can we help you
+                Book a 15-minute consultation to explore how VisionzLab can help you
               </h2>
               <a
                 href="https://frankgoortani.typeform.com/to/VaoYV6iJ"
@@ -457,7 +455,7 @@
           </div>
           <div class="home-content1">
             <div class="home-contact">
-              <span class="home-number">info@visionzlab.com</span>
+              <span class="home-number">frank@goortani.com</span>
               <span class="home-number1">+1 647.983.5277</span>
             </div>
             <div class="home-links-row">
@@ -470,20 +468,20 @@
                   Services
                 </a>
                 <a
-                  href="https://www.linkedin.com/in/frankgoortani/"
+                  href="https://goortani.com"
                   target="_blank"
                   rel="noreferrer noopener"
                   class="home-link07"
                 >
-                  Team
+                  Portfolio
                 </a>
                 <a
-                  href="https://frankgoortani.typeform.com/to/VaoYV6iJ"
+                  href="https://architect.solutions"
                   target="_blank"
                   rel="noreferrer noopener"
                   class="home-link08"
                 >
-                  Careers
+                  Blog
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- personalize meta tags, hero, and about section to highlight Frank Goortani's AI-focused consulting
- add Portfolio and Blog links to goortani.com and architect.solutions in navigation and footer
- refresh service descriptions and update contact info

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68ae21789d14832da951a4b93c34b7d6